### PR TITLE
ensure that the partial gets compiled so that other handlebars plugins c...

### DIFF
--- a/index.js
+++ b/index.js
@@ -264,7 +264,8 @@ Hbs.prototype.registerPartials = function () {
       // Read all the partial from disk
       partials = yield files.map(read);
       for(var i=0; i!=partials.length; i++) {
-        self.registerPartial(names[i], partials[i]);
+        var compiled = self.handlebars.compile(partials[i]);
+        self.registerPartial(names[i], compiled);
       }
 
       self.partialsRegistered = true;


### PR DESCRIPTION
...an access as a function

for cases like

hbs.handlebars.partials[partialName](data)

This is similar to what Swag does when registering a partial function.  Otherwise all the partials[] contains are strings.

