### PR TITLE
add koa state support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,25 @@ The plan for koa-hbs is to offer identical functionality as express-hbs
 - `contentHelperName`: Alter `contentFor` helper name
 - `blockHelperName`: Alter `block` helper name
 
+### Locals
+
+Application local variables (```[this.state](https://github.com/koajs/koa/blob/master/docs/api/context.md#ctxstate)```) are provided to all templates rendered within the application.
+
+```javascript
+app.use(function *() {
+  this.state.title = 'My App';
+  this.state.email = 'me@myapp.com';
+});
+```
+
+The state object is a JavaScript Object. The properties added to it will be exposed as local variables within your views.
+
+```
+<title>{{title}}</title>
+
+<p>Contact : {{email}}</p>
+```
+
 ## Example
 You can run the included example via `npm install koa` and
 `node --harmony app.js` from the example folder.

--- a/index.js
+++ b/index.js
@@ -156,7 +156,8 @@ Hbs.prototype.createRenderer = function() {
     var tplPath = path.join(hbs.viewPath, tpl + hbs.extname),
       template, rawTemplate, layoutTemplate;
 
-    locals = merge(hbs.locals, locals || {});
+    locals = merge(this.state || {}, locals || {});
+    locals = merge(hbs.locals, locals);
 
     // Initialization... move these actions into another function to remove
     // unnecessary checks

--- a/test/app/assets/locals.hbs
+++ b/test/app/assets/locals.hbs
@@ -1,1 +1,2 @@
 <h1>{{title}}</h1>
+<article>{{article}}</article>

--- a/test/app/index.js
+++ b/test/app/index.js
@@ -26,7 +26,7 @@ var create = function(opts) {
       ]
     });
   });
-  
+
   app.get('/nestedPartials', function*() {
     yield this.render('nestedPartials' );
   });
@@ -64,6 +64,13 @@ var create = function(opts) {
     obj.title = 'Bar';
     obj.recursive = obj;
     yield this.render('locals', obj);
+  });
+
+  app.get('/localsState', function *() {
+    this.state = { title: 'Foo', article: 'State' };
+    yield this.render('locals', {
+      title: 'Bar'
+    });
   });
   return app;
 };

--- a/test/render.js
+++ b/test/render.js
@@ -15,7 +15,11 @@ describe('rendering', function() {
 
   it('should render into the response body', function (done) {
     app = testApp.create({
-      viewPath: __dirname + '/app/assets'
+      viewPath: __dirname + '/app/assets',
+      locals: {
+        title: 'hbs',
+        article: 'locals'
+      }
     });
 
     request(app.listen())
@@ -183,6 +187,17 @@ describe('rendering', function() {
           done();
         });
     });
+
+    it('should render "Bar" and "State"', function (done) {
+      request(app.listen())
+      .get('/localsState')
+      .expect(200)
+      .end(function (err, content) {
+        assert.ok(/Bar/.test(content.text));
+        assert.ok(/State/.test(content.text));
+        done();
+      });
+    });
   });
 });
 
@@ -216,7 +231,7 @@ describe('var conflict', function () {
       .get('/first')
       .expect(200)
       .end(function (err, content) {
-        assert.equal(content.text, '<h1>hbs</h1>');
+        assert.ok(content.text.indexOf('<h1>hbs</h1>') !== -1);
         done();
       });
   });
@@ -226,7 +241,7 @@ describe('var conflict', function () {
       .get('/second')
       .expect(200)
       .end(function (err, content) {
-        assert.equal(content.text, '<h1></h1>');
+        assert.ok(content.text.indexOf('<h1></h1>') !== -1);
         done();
       });
   });


### PR DESCRIPTION
As stated in [Koa doc](https://github.com/koajs/koa/blob/master/docs/api/context.md#ctxstate), "locals" variable should be set in this.state so we need to merge locals with it.

Locals have this overwrite hierarchy : locals > this.state > options.locals

btw i don't really see why there is `locals` in options as it's not contextual.