### PR TITLE
Fix view path array bug

### DIFF
--- a/test/app/index.js
+++ b/test/app/index.js
@@ -72,6 +72,10 @@ var create = function(opts) {
       title: 'Bar'
     });
   });
+
+  app.get('/tplInOtherDir', function *() {
+    yield this.render('tplInOtherDir');
+  });
   return app;
 };
 

--- a/test/app/otherViews/tplInOtherDir.hbs
+++ b/test/app/otherViews/tplInOtherDir.hbs
@@ -1,0 +1,1 @@
+<p>I'm in another directory!</p>

--- a/test/render.js
+++ b/test/render.js
@@ -253,7 +253,11 @@ describe('list of view paths', function () {
   before(function () {
     // Create app which specifies layouts
     app = testApp.create({
-      viewPath: [__dirname + '/app/assets', __dirname + '/app/otherViews'],
+      viewPath: [
+        __dirname + '/app/assets',
+        __dirname + '/app/otherViews',
+        __dirname + '/app/pathThatDoesNotExist'
+      ],
       partialsPath: __dirname + '/app/assets/partials',
       layoutsPath: __dirname + '/app/assets/layouts'
     });

--- a/test/render.js
+++ b/test/render.js
@@ -246,3 +246,29 @@ describe('var conflict', function () {
       });
   });
 });
+
+describe('list of view paths', function () {
+  var app;
+  var server;
+  before(function () {
+    // Create app which specifies layouts
+    app = testApp.create({
+      viewPath: [__dirname + '/app/assets', __dirname + '/app/otherViews'],
+      partialsPath: __dirname + '/app/assets/partials',
+      layoutsPath: __dirname + '/app/assets/layouts'
+    });
+
+    server = app.listen();
+  });
+
+  it('searches for views in all paths', function () {
+    request(server)
+      .get('/tplInOtherDir')
+      .expect(200)
+      .end(function (err, content) {
+        console.log(content.text);
+        assert.ok(content.text.indexOf('I\'m in another directory!') !== -1);
+        done();
+      });
+  });
+});


### PR DESCRIPTION
The docs say that the `viewPath` option can be an Array or a String. In practice, it could only be a String. This patch adds support for the viewPath being an Array or a String.

Resolves #36.